### PR TITLE
feat: GitHub Actions CI 설정 추가

### DIFF
--- a/ClassReservation/.github/workflows/ci.yml
+++ b/ClassReservation/.github/workflows/ci.yml
@@ -1,0 +1,21 @@
+name: Java CI with Maven
+
+on:
+  push:
+    branches: [ main, minju, jinwon, seonghun, seeum, jikwang ]
+  pull_request:
+    branches: [ main, minju, jinwon, seonghun, seeum, jikwang ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up JDK 21
+        uses: actions/setup-java@v3
+        with:
+          java-version: '21'
+          distribution: 'temurin'
+      - name: Build with Maven
+        run: mvn -B test
+        working-directory: ./ClassReservation


### PR DESCRIPTION
## 주요 변경 사항
- `.github/workflows/ci.yml` 파일을 추가하여 GitHub Actions 기반의 자동 테스트 워크플로우를 설정했습니다.
- 브랜치 `main`과 각 팀원 브랜치에서 push/pull request 이벤트 발생 시, Maven 기반 `mvn test` 자동 실행이 이뤄집니다.

## 목적
- 팀원 전체의 코드 품질을 CI로 관리하고, PR마다 테스트를 자동으로 확인할 수 있도록 하기 위함입니다.

> 이 PR은 CI 설정만 포함되어 있으며, 코드 충돌을 방지하기 위해 `main` 최신 상태 기반으로 분리한 브랜치(`ci-only`)에서 작성되었습니다.

----
→ 이제 모든 브랜치에서 PR/push 시 Maven 테스트가 자동으로 수행됩니다.
